### PR TITLE
Updated Required Package List for RHEL8 ppcle

### DIFF
--- a/tasks/RedHat/installation.yml
+++ b/tasks/RedHat/installation.yml
@@ -62,7 +62,7 @@
   register: sap_hana_preconfigure_register_reboot_required
   changed_when: false
   failed_when: sap_hana_preconfigure_register_reboot_required.rc > 1 
-  when: ( ansible_distribution_version >= "7.3" ) and ( ansible_distribution_major_version == "7" )
+  when: ( ansible_distribution_version >= "7.3" ) and ( ansible_distribution_major_version >= "7" )
 
 # This did not work properly because, the last register variable is used in the next when statement.
 #- name: check if reboot is required (7.2)

--- a/vars/RedHat_7.yml
+++ b/vars/RedHat_7.yml
@@ -63,6 +63,10 @@ sap_hana_preconfigure_min_packages_7.6:
 sap_hana_preconfigure_min_packages_7.7:
         - [ 'kernel' , '3.10.0-1062.1.1.el7' ]
 
+# Add empty definitions for upcoming latest releases
+sap_hana_preconfigure_min_packages_7.8:
+sap_hana_preconfigure_min_packages_7.9:
+
 sap_hana_preconfigure_min_pkgs: "{{ lookup('vars','sap_hana_preconfigure_min_packages_' + ansible_distribution_version|string ) }}"
 
 sap_hana_preconfigure_packages:

--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -72,6 +72,9 @@ sap_hana_preconfigure_packages:
     - libtool-ltdl
     # SAP NOTE 2292690
     - tuned-profiles-sap-hana
+    # required package for checking, if reboot is needed after package installation
+    # It is not installed by default group
+    - yum-utils
     # SAP NOTE 22455582
 #
 #   libtool ltdl: https://answers.sap.com/questions/476177/hana-db-installation-ended-with-exit-code-127.html

--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -9,18 +9,20 @@ sap_hana_preconfigure_sapnotes:
         - "2382421"
 #        - "2235581" # no specific requirements for RHEL 8 yet
 
-# https://www14.software.ibm.com/support/customercare/sas/f/lopdiags/home.html
-# no list available yet for RHEL 8, so let's just use those from the RHEL 7 list
-#   which are avaiable for RHEL 8:
+# The packages for RHEL8 are almost the same as for RHEL7
+# IBM publishes the packages as a repository here:
+# https://public.dhe.ibm.com/software/server/POWER/Linux/yum/OSS/RHEL/8/ppc64le/
+# To install the packages you need to create an appropriate repofile 
+# or clone this repository (e.g. with Satellite product)
 sap_hana_preconfigure_required_ppc64le:
         - librtas
-#        - src
-#        - rsct.core.utils
-#        - rsct.core
-#        - rsct.basic
-#        - rsct.opt.storagerm
-#        - devices.chrp.base.ServiceRM
-#        - DynamicRM
+        - src
+        - rsct.core.utils
+        - rsct.core
+        - rsct.basic
+        - rsct.opt.storagerm
+        - devices.chrp.base.ServiceRM
+        - DynamicRM
         - ncurses-libs
         - readline
         - sqlite
@@ -33,10 +35,10 @@ sap_hana_preconfigure_required_ppc64le:
         - libvpd
         - libservicelog
         - servicelog
-#        - powerpc-utils
-#        - powerpc-utils-python
+        - powerpc-utils
+#        - powerpc-utils-python # this package is no longer available for RHEL8
         - ppc64-diag
-#        - IBMinvscout
+        - IBMinvscout
 
 # Minimum required package levels for RHEL 8:
 sap_hana_preconfigure_min_packages_8:


### PR DESCRIPTION
Updating Power 8 Packages:
See comments in https://github.com/linux-system-roles/sap-hana-preconfigure/issues/68

The following packages are required for ppcle on POWER9 according to IBM:

yum install librtas src rsct.core.utils rsct.core rsct.basic rsct.opt.storagerm
devices.chrp.base.ServiceRM DynamicRM ncurses-libs readline sqlite
sg3_utils libgcc libstdc++ zlib iprutils lsvpd libvpd libservicelog
servicelog powerpc-utils ppc64-diag IBMinvscout

The are now available in the follwoing repository:
https://public.dhe.ibm.com/software/server/POWER/Linux/yum/OSS/RHEL/8/ppc64le/

The are valid for RHEL8.0 and 8.1

A second patch is done to enable reboot on RHEL8. See comments in 
https://github.com/linux-system-roles/sap-hana-preconfigure/issues/67
